### PR TITLE
Fix Flow return type in PersonRepository

### DIFF
--- a/app/src/main/java/com/halil/ozel/recyclerviewsample/PersonRepository.kt
+++ b/app/src/main/java/com/halil/ozel/recyclerviewsample/PersonRepository.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.flowOf
 @Singleton
 class PersonRepository @Inject constructor() {
     fun getAllData(): Flow<List<Person>> = flowOf(
+        listOf(
         Person(
             firstName = "Taylor",
             lastName = "Swift",
@@ -114,6 +115,7 @@ class PersonRepository @Inject constructor() {
             nation = "UK",
             musicType = "Pop",
             imageUrl = "https://picsum.photos/seed/anne/200"
+        )
         )
     )
 }


### PR DESCRIPTION
## Summary
- fix the return type of `PersonRepository.getAllData` so it emits a list

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6857ee7bda4c832b9c505602732f4e8f