### PR TITLE
Improve item layout and show images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# 🎶 Compose Artist Table
+# 🎶 Compose Artist List
 
 ![Compose RecyclerView](lazycolumn.png)
 
-A **Jetpack Compose** sample app that renders a list of artists in a neat, table-style layout. Each row shows age, name, country, and music genre, complete with row & column dividers and dynamic text wrapping. Perfect for demos, tutorials, or as a starting point for your own Compose data grids! ✨
+A **Jetpack Compose** sample app that renders a list of artists in a clean, card-based layout. Each item shows an image, age, name, country and music genre. Perfect for demos, tutorials, or as a starting point for your own Compose lists! ✨
 
 ---
 
 ## 🚀 Features
 
-- **Table-style LazyColumn** with horizontal & vertical dividers  
-- **Multi-line support**: long names and genres wrap into new lines  
-- **Dynamic data**: load from a simple `PersonRepository`  
-- **Material 3** typography & theming  
-- **Previewable UI** with `@Preview` functions  
+- **Modern card layout** with artist photos
+- **Multi-line support**: long names and genres wrap into new lines
+- **Dynamic data**: load from a simple `PersonRepository`
+- **Material 3** typography & theming
+- **Previewable UI** with `@Preview` functions
 
 ---
 

--- a/app/src/main/java/com/halil/ozel/recyclerviewsample/CustomItem.kt
+++ b/app/src/main/java/com/halil/ozel/recyclerviewsample/CustomItem.kt
@@ -4,79 +4,70 @@ package com.halil.ozel.recyclerviewsample
  * Created by halilozel1903 on 11.05.2025.
  */
 
-import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.material3.HorizontalDivider
-import coil.compose.AsyncImage
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.CardDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import coil.compose.AsyncImage
+import androidx.compose.ui.layout.ContentScale
 
 @Composable
 fun CustomItem(person: Person) {
-    val columns = listOf(
-        Triple(person.age.toString(), 1f, MaterialTheme.typography.bodyLarge),
-        Triple("${person.firstName} ${person.lastName}", 3f, MaterialTheme.typography.bodyLarge),
-        Triple(person.nation, 2f, MaterialTheme.typography.bodyMedium),
-        Triple(person.musicType, 3f, MaterialTheme.typography.bodyMedium)
-    )
-
-    Row(
+    Card(
         modifier = Modifier
             .fillMaxWidth()
-            .height(IntrinsicSize.Min)
+            .padding(horizontal = 12.dp, vertical = 6.dp),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.elevatedCardColors()
     ) {
-        AsyncImage(
-            model = person.imageUrl,
-            contentDescription = null,
+        Row(
             modifier = Modifier
-                .width(64.dp)
-                .padding(8.dp)
-        )
-        TableDivider()
-        columns.forEachIndexed { index, (value, weight, style) ->
-            if (index > 0) TableDivider()
-            TableCell(text = value, weight = weight, style = style)
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            AsyncImage(
+                model = person.imageUrl,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .size(64.dp)
+                    .clip(RoundedCornerShape(8.dp))
+            )
+
+            Spacer(modifier = Modifier.size(12.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "${person.firstName} ${person.lastName}",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    text = "${person.age} • ${person.nation}",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = person.musicType,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
         }
     }
-}
-
-@Composable
-private fun RowScope.TableCell(
-    text: String,
-    weight: Float,
-    style: TextStyle,
-    maxLines: Int = 2
-) {
-    Text(
-        text = text,
-        style = style,
-        modifier = Modifier
-            .weight(weight)
-            .padding(8.dp),
-        maxLines = maxLines
-    )
-}
-
-@Composable
-private fun TableDivider() {
-    HorizontalDivider(
-        modifier = Modifier
-            .fillMaxHeight()
-            .width(1.dp),
-        color = Color.Gray
-    )
 }
 
 @Composable

--- a/app/src/main/java/com/halil/ozel/recyclerviewsample/MainActivity.kt
+++ b/app/src/main/java/com/halil/ozel/recyclerviewsample/MainActivity.kt
@@ -4,18 +4,13 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.halil.ozel.recyclerviewsample.ui.theme.RecyclerViewSampleTheme
@@ -37,24 +32,13 @@ class MainActivity : ComponentActivity() {
 
     @Composable
     fun PersonList(people: List<Person>) {
-        Box(
+        LazyColumn(
             modifier = Modifier
                 .fillMaxWidth()
-                .wrapContentHeight()
-                .padding(12.dp)
-                .border(1.dp, Color.Gray)
+                .padding(vertical = 8.dp)
         ) {
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .wrapContentHeight()
-            ) {
-                itemsIndexed(people) { index, person ->
-                    if (index > 0) {
-                        HorizontalDivider(thickness = 1.dp, color = Color.Gray)
-                    }
-                    CustomItem(person)
-                }
+            items(people) { person ->
+                CustomItem(person)
             }
         }
     }


### PR DESCRIPTION
## Summary
- refresh README to reflect card-based list
- refactor `CustomItem` with modern card UI and show images clearly
- simplify `PersonList` implementation

## Testing
- `./gradlew --version` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6857f0936118832ba6740dfb02ca2ba5