### PR TITLE
Add detail screen and update list view

### DIFF
--- a/app/src/main/java/com/halil/ozel/recyclerviewsample/CustomItem.kt
+++ b/app/src/main/java/com/halil/ozel/recyclerviewsample/CustomItem.kt
@@ -4,6 +4,7 @@ package com.halil.ozel.recyclerviewsample
  * Created by halilozel1903 on 11.05.2025.
  */
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -26,11 +27,15 @@ import coil.compose.AsyncImage
 import androidx.compose.ui.layout.ContentScale
 
 @Composable
-fun CustomItem(person: Person) {
+fun CustomItem(
+    person: Person,
+    onClick: () -> Unit
+) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 12.dp, vertical = 6.dp),
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+            .clickable { onClick() },
         shape = RoundedCornerShape(12.dp),
         colors = CardDefaults.elevatedCardColors()
     ) {
@@ -43,7 +48,7 @@ fun CustomItem(person: Person) {
             AsyncImage(
                 model = person.imageUrl,
                 contentDescription = null,
-                contentScale = ContentScale.Crop,
+                contentScale = ContentScale.Fit,
                 modifier = Modifier
                     .size(64.dp)
                     .clip(RoundedCornerShape(8.dp))
@@ -53,16 +58,12 @@ fun CustomItem(person: Person) {
 
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = "${person.firstName} ${person.lastName}",
+                    text = "\uD83C\uDFB6 ${person.firstName} ${person.lastName}",
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold
                 )
                 Text(
-                    text = "${person.age} • ${person.nation}",
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                Text(
-                    text = person.musicType,
+                    text = "\uD83C\uDF82 ${person.age}",
                     style = MaterialTheme.typography.bodyMedium
                 )
             }
@@ -81,6 +82,7 @@ fun CustomItemPreview() {
             nation = "Italy",
             musicType = "Pop / Rap",
             imageUrl = "https://picsum.photos/seed/baby/200"
-        )
+        ),
+        onClick = {}
     )
 }

--- a/app/src/main/java/com/halil/ozel/recyclerviewsample/MainActivity.kt
+++ b/app/src/main/java/com/halil/ozel/recyclerviewsample/MainActivity.kt
@@ -4,12 +4,22 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import coil.compose.AsyncImage
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -24,21 +34,29 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             val people = viewModel.people.collectAsState().value
+            var selectedPerson by remember { mutableStateOf<Person?>(null) }
             RecyclerViewSampleTheme {
-                PersonList(people)
+                if (selectedPerson == null) {
+                    PersonList(people) { selectedPerson = it }
+                } else {
+                    PersonDetail(person = selectedPerson!!) { selectedPerson = null }
+                }
             }
         }
     }
 
     @Composable
-    fun PersonList(people: List<Person>) {
+    fun PersonList(
+        people: List<Person>,
+        onItemClick: (Person) -> Unit
+    ) {
         LazyColumn(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(vertical = 8.dp)
         ) {
             items(people) { person ->
-                CustomItem(person)
+                CustomItem(person = person, onClick = { onItemClick(person) })
             }
         }
     }
@@ -57,8 +75,37 @@ class MainActivity : ComponentActivity() {
                         musicType = "Pop",
                         imageUrl = ""
                     )
-                )
+                ),
+                onItemClick = {}
             )
+        }
+    }
+
+    @Composable
+    fun PersonDetail(person: Person, onBack: () -> Unit) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+        ) {
+            AsyncImage(
+                model = person.imageUrl,
+                contentDescription = null,
+                contentScale = ContentScale.Fit,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp)
+            )
+            Text(text = "Name: ${person.firstName} ${person.lastName}")
+            Text(text = "Age: ${person.age}")
+            Text(text = "Nation: ${person.nation}")
+            Text(text = "Music Type: ${person.musicType}")
+            Button(
+                onClick = onBack,
+                modifier = Modifier.padding(top = 16.dp)
+            ) {
+                Text(text = "Back")
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- tweak `CustomItem` to only show name and age with emojis
- add click handling and proportional image scaling
- add `PersonDetail` composable for full JSON data
- display detail screen when a list item is clicked

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6857fa41a528832babab7711ea289e5d