### PR TITLE
Add emojis and sorting

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.material.icons.extended)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.gson)
     implementation(libs.hilt.android)

--- a/app/src/main/java/com/halil/ozel/recyclerviewsample/CustomItem.kt
+++ b/app/src/main/java/com/halil/ozel/recyclerviewsample/CustomItem.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import coil.compose.AsyncImage
 import androidx.compose.ui.layout.ContentScale
+import com.halil.ozel.recyclerviewsample.genreToEmoji
 
 @Composable
 fun CustomItem(
@@ -58,7 +59,7 @@ fun CustomItem(
 
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = "\uD83C\uDFB6 ${person.firstName} ${person.lastName}",
+                    text = "${genreToEmoji(person.musicType)} ${person.firstName} ${person.lastName}",
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold
                 )

--- a/app/src/main/java/com/halil/ozel/recyclerviewsample/EmojiUtils.kt
+++ b/app/src/main/java/com/halil/ozel/recyclerviewsample/EmojiUtils.kt
@@ -1,0 +1,25 @@
+package com.halil.ozel.recyclerviewsample
+
+fun genreToEmoji(genre: String): String {
+    val lower = genre.lowercase()
+    return when {
+        "hip hop" in lower || "rap" in lower -> "\uD83C\uDF99" // studio microphone
+        "reggaeton" in lower || "latin" in lower -> "\uD83C\uDFB6"
+        "country" in lower -> "\uD83E\uDD20"
+        "dance" in lower -> "\uD83D\uDC83"
+        "indie" in lower -> "\uD83C\uDFB8"
+        else -> "\uD83C\uDFB5"
+    }
+}
+
+fun nationToFlag(nation: String): String = when (nation) {
+    "USA" -> "\uD83C\uDDFA\uD83C\uDDF8"
+    "Trinidad and Tobago" -> "\uD83C\uDDF9\uD83C\uDDF9"
+    "Canada" -> "\uD83C\uDDE8\uD83C\uDDE6"
+    "Italy" -> "\uD83C\uDDEE\uD83C\uDDF9"
+    "Colombia" -> "\uD83C\uDDE8\uD83C\uDDF4"
+    "Dominican Republic" -> "\uD83C\uDDE9\uD83C\uDDF4"
+    "Greece" -> "\uD83C\uDDEC\uD83C\uDDF7"
+    "UK" -> "\uD83C\uDDEC\uD83C\uDDE7"
+    else -> ""
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", v
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
+androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add mapping helpers for music and nation emojis
- show emoji by genre in list items
- include material icons for back navigation
- sort list by age or name
- show nation flag and add toolbar in detail screen

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6857fc6d2934832bbb426ce3bfc8b832